### PR TITLE
Add Wiki testing strategy documents

### DIFF
--- a/projects/wiki/docs/impl-plan.md
+++ b/projects/wiki/docs/impl-plan.md
@@ -4,7 +4,7 @@
 
 - **プロダクト名**: KotaServer Wiki
 - **目的**: CMS（kotaserver-web-admin）で管理するコンテンツを Wiki ページとして Astro の静的サイト上で配信する
-- **参照ドキュメント**: [要件定義書](requirements.md), [仕様書](specification.md)
+- **参照ドキュメント**: [要件定義書](requirements.md), [仕様書](specification.md), [テスト戦略書](testing-strategy.md)
 
 ## 前提条件・技術スタック
 
@@ -47,6 +47,34 @@
 
 **補足**: この段階では Markdown を HTML 変換せず、生テキストで表示する。動作確認ができれば十分。環境変数が未設定の場合はビルド時にわかりやすいエラーメッセージを出す。
 
+**テスト（ユニット）**:
+
+- [ ] Vitest + cheerio + Playwright をセットアップする（`pnpm add -D vitest cheerio @playwright/test && npx playwright install chromium`、`vitest.config.ts`・`playwright.config.ts` 作成、`package.json` にスクリプト追加）
+- [ ] `src/lib/__tests__/cms-client.test.ts` を作成し、以下のテストケースを実装:
+  - `fetchCms` が `X-API-Key` ヘッダーを正しく付与すること
+  - `fetchCms` が `CMS_API_URL` + パスで正しい URL を構築すること
+  - `getPages` が正常レスポンスをパースして返すこと
+  - `getPageBySlug` が slug を URL に含めてリクエストし、レスポンスを返すこと
+  - API エラー時（401/404/500）に適切なメッセージと共に例外をスローすること
+  - `CMS_API_URL` / `CMS_API_KEY` が未設定の場合にわかりやすいエラーをスローすること
+- [ ] `vitest run --project unit` が全件パスすること
+
+**テスト（ビルド成果物）**:
+
+- [ ] テストハーネス基盤を構築する:
+  - `src/__tests__/fixtures/` にフィクスチャ JSON（pages, navigation, media）を作成
+  - `src/__tests__/helpers/mock-cms-server.ts` — モック CMS HTTP サーバー（`node:http`、ポート 18080）
+  - `src/__tests__/helpers/build.ts` — `astro build` 実行ヘルパー
+  - `src/__tests__/helpers/html.ts` — HTML 読み込み・cheerio パースヘルパー
+- [ ] `src/__tests__/build-output/iteration-1.test.ts` を作成し、以下を検証:
+  - `dist/wiki/{slug}/index.html` が生成されること
+  - HTML 内にフィクスチャのページタイトルが含まれること
+  - HTML 内にフィクスチャの本文テキストが含まれること
+  - `dist/wiki/` 内のディレクトリがフィクスチャの slug のみであること
+- [ ] `vitest run --project build` が全件パスすること
+
+※ Iteration 1 ではスクリーンショット確認なし（CSS スタイリング未実装のため）
+
 ---
 
 ### Iteration 2: Markdown レンダリング & ページレイアウト
@@ -64,6 +92,32 @@
 - [ ] `<title>` タグにページタイトルを反映（`{title} | KotaServer` 形式）
 - [ ] Markdown コンテンツ用の基本的な CSS スタイルを追加（見出し、段落、リスト、コードブロック等）
 
+**テスト（ユニット）**:
+
+- [ ] `src/lib/__tests__/markdown.test.ts` を作成し、以下のテストケースを実装:
+  - 見出し・段落・リスト・コードブロックが正しい HTML に変換されること
+  - 空文字列を渡した場合にエラーにならず空文字列を返すこと
+- [ ] `vitest run --project unit` が全件パスすること
+
+**テスト（ビルド成果物）**:
+
+- [ ] `src/__tests__/build-output/iteration-2.test.ts` を作成し、以下を検証:
+  - ビルド済み HTML 内に `<h2>`, `<ul>`, `<pre><code>` 等の Markdown 由来の HTML 要素が存在すること
+  - `<title>` の内容が `{ページタイトル} | KotaServer` 形式にマッチすること
+  - WikiLayout のセマンティック要素（`<header>`, `<main>`, `<footer>`）が存在すること
+- [ ] `vitest run --project build` が全件パスすること
+
+**テスト（スクリーンショット確認）**:
+
+- [ ] `src/__tests__/screenshots/capture.test.ts` を作成し、以下のスクリーンショットを撮影:
+  - `/wiki/{slug}` 個別ページ — デスクトップ（1280x720）
+  - `/wiki/{slug}` 個別ページ — モバイル（375x667）
+- [ ] `playwright test` を実行してスクリーンショットを `test-results/` に保存
+- [ ] エージェントがスクリーンショットを読み込み、以下を視覚確認:
+  - Markdown（見出し・段落・リスト・コードブロック）が読みやすくレンダリングされていること
+  - WikiLayout のヘッダー・コンテンツ・フッターが適切に配置されていること
+  - モバイルビューポートでレイアウトが崩れていないこと
+
 ---
 
 ### Iteration 3: ページ一覧
@@ -77,6 +131,32 @@
 - [ ] `src/components/WikiCard.astro` を作成 — ページタイトルと更新日時を表示するカードコンポーネント
 - [ ] `src/pages/wiki/index.astro` を作成 — `getPages()` で全公開ページを取得し、更新日時の降順で `WikiCard` を一覧表示
 - [ ] Wiki ページ一覧用の CSS スタイルを追加
+
+**テスト（ユニット）**:
+
+- [ ] 新規テスト追加なし（ページ一覧は Astro テンプレートのみでテスト対象のロジックがない）
+- [ ] `vitest run --project unit` が既存テスト全件パスすること（リグレッションなし）
+
+**テスト（ビルド成果物）**:
+
+- [ ] `src/__tests__/build-output/iteration-3.test.ts` を作成し、以下を検証:
+  - `dist/wiki/index.html` が生成されること
+  - カード要素の数がフィクスチャのページ数と一致すること
+  - 各カード内にフィクスチャのタイトル・更新日時テキストが含まれること
+  - カードが更新日時の降順で並んでいること（カード要素を順に取得して日時を比較）
+  - 各カードの `<a href>` が `/wiki/{slug}` 形式であること
+  - 空配列フィクスチャでビルドし、`dist/wiki/index.html` が生成されエラーにならないこと
+- [ ] `vitest run --project build` が全件パスすること
+
+**テスト（スクリーンショット確認）**:
+
+- [ ] `capture.test.ts` に一覧ページのスクリーンショットを追加:
+  - `/wiki/` 一覧ページ — デスクトップ（1280x720）
+  - `/wiki/` 一覧ページ — モバイル（375x667）
+- [ ] エージェントがスクリーンショットを読み込み、以下を視覚確認:
+  - カード一覧がグリッド状に配置されていること
+  - 各カードにタイトルと日時が視認できること
+  - モバイルビューポートでカードが縦並びになっていること
 
 ---
 
@@ -94,6 +174,33 @@
 - [ ] `PageLayout.astro` にナビゲーションコンポーネントを組み込む
 - [ ] ナビゲーションの CSS スタイルを追加（レスポンシブ対応含む）
 
+**テスト（ユニット）**:
+
+- [ ] `cms-client.test.ts` に `getNavigation` のテストケースを追加:
+  - `getNavigation` が正常レスポンスをパースして返すこと
+- [ ] `src/lib/__tests__/navigation.test.ts` を作成し、以下のテストケースを実装:
+  - ナビ項目が `sortOrder` 昇順でソートされること
+  - `pageId` が存在するナビ項目に `/wiki/{slug}` リンクが生成されること
+  - `pageId` が `null` のナビ項目はラベルのみ（リンクなし）で処理されること
+  - `pageId` に対応するページが未公開（ページ一覧に存在しない）の場合、該当項目がフィルタまたはリンクなしになること
+- [ ] `vitest run --project unit` が全件パスすること
+
+**テスト（ビルド成果物）**:
+
+- [ ] `src/__tests__/build-output/iteration-4.test.ts` を作成し、以下を検証:
+  - ナビ要素内にフィクスチャのラベルテキストが含まれること
+  - `pageId` 付きナビ項目の `<a href>` が `/wiki/{slug}` を指していること
+  - ナビの最初のリンクが `/`（トップページ）であること
+  - ナビ項目の順序がフィクスチャの `sortOrder` 昇順と一致すること
+- [ ] `vitest run --project build` が全件パスすること
+
+**テスト（スクリーンショット確認）**:
+
+- [ ] スクリーンショットを再撮影し、エージェントが以下を視覚確認:
+  - ナビゲーションメニューがヘッダーに表示されていること
+  - ナビ項目のテキストが視認でき、リンクらしい見た目であること
+  - モバイルビューポートでナビゲーションが適切に折り返し/収納されていること
+
 ---
 
 ### Iteration 5: メディア URL 解決 & OGP
@@ -110,6 +217,29 @@
 
 **補足**: メディア URL の変換は `marked` の renderer オプションで `image` メソッドをオーバーライドして実装する。
 
+**テスト（ユニット）**:
+
+- [ ] `markdown.test.ts` にメディア URL 解決のテストケースを追加:
+  - `![alt](/media/image.png)` が `<img src="{CMS_API_URL}/media/image.png">` に変換されること
+  - 外部 URL の画像（`https://example.com/img.png`）はそのまま維持されること
+- [ ] `vitest run --project unit` が全件パスすること
+
+**テスト（ビルド成果物）**:
+
+- [ ] `src/__tests__/build-output/iteration-5.test.ts` を作成し、以下を検証:
+  - ビルド済み HTML 内の `<img src>` が `{CMS_API_URL}/media/...` 形式に解決されていること
+  - 外部 URL の `<img src>` が���換されていないこと
+  - 個別ページ HTML に `og:title`, `og:type`, `og:url` の `<meta>` 要素が存在し、値が正しいこと
+  - `dist/wiki/index.html` にもメタタグが設定されていること
+- [ ] `vitest run --project build` が全件パスすること
+
+**テスト（スクリーンショット確認）**:
+
+- [ ] フィクスチャに画像を含む Markdown ページを追加してスクリーンショットを再撮影
+- [ ] エージェントがスクリーンショットを読み込み、以下を視覚確認:
+  - 画像がページ内に表示されていること（壊れた画像アイコンでないこと）
+  - 画像がコンテンツ幅に適切に収まっていること
+
 ---
 
 ### Iteration 6: Webhook 再ビルド設定
@@ -125,6 +255,23 @@
 - [ ] CMS でページを公開し、Webhook が発火してサイトが再ビルドされることを確認する
 
 **補足**: 具体的な設定手順はデプロイ先（Cloudflare Pages、Vercel、GitHub Actions 等）に依存する。Website 側のコード変更は不要。
+
+**テスト（ユニット）**:
+
+- [ ] 新規テスト追加なし（Website 側のコード変更がない）
+- [ ] `vitest run --project unit` が全件パスすること（リグレッションなし）
+
+**テスト（ビルド成果物）**:
+
+- [ ] 新規テスト追加なし（Website 側のコード変更がない）
+- [ ] `vitest run --project build` が全件パスすること（リグレッションなし）
+
+**自動化対象外（手動確認）**:
+
+- [ ] CMS でページを公開し、Webhook が発火してサイトが自動で再ビルド・デプロイされること
+- [ ] 再ビルド後、新しいページが `/wiki/{slug}` で表示されること
+
+※ Webhook 連携は外部 CI/CD サービスとの結合であり、テストハーネスのスコープ外
 
 ---
 

--- a/projects/wiki/docs/testing-harness-analysis.md
+++ b/projects/wiki/docs/testing-harness-analysis.md
@@ -1,0 +1,301 @@
+# 自動テストハーネス検討
+
+## 結論
+
+手動テスト項目の **大半は自動化可能**。SSG の「ビルド成果物が静的 HTML ファイル」という特性を活かし、ビルド後の HTML を解析するアプローチで実現できる。
+
+自動化不可能なのは **CSS の視覚的なレイアウト確認** のみ。ただし、これはエージェント自走ワークフローにおいてはスコープ外として許容できる。
+
+---
+
+## 1. 基本アプローチ
+
+```
+フィクスチャ JSON  ──▶  モック CMS サーバー  ──▶  astro build  ──▶  dist/ の HTML を解析
+                        (localhost:18080)          (SSG ビルド)        (cheerio でパース)
+```
+
+1. **モック CMS サーバー** — フィクスチャデータを返す軽量 HTTP サーバーをテストプロセス内で起動
+2. **Astro ビルド実行** — モック CMS を向いた環境変数で `astro build` を実行し、`dist/` に静的 HTML を生成
+3. **HTML 解析** — 生成された HTML ファイルを読み込み、cheerio（または node-html-parser）で DOM をパースしてアサーション
+
+ブラウザは不要。Node.js だけで完結する。
+
+---
+
+## 2. 手動テスト項目の自動化可否
+
+### Iteration 1: CMS API 接続 & 最初のページ表示
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| `/wiki/{slug}` にタイトルと本文が表示される | **可** | `dist/wiki/{slug}/index.html` を読み込み、タイトル・本文テキストの存在をアサート |
+| 存在しない slug にアクセスした場合の動作 | **可** | `dist/` 内に想定外の slug ディレクトリが生成されていないことをアサート |
+
+### Iteration 2: Markdown レンダリング & ページレイアウト
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| Markdown が正しくレンダリングされる | **可** | HTML 内に `<h2>`, `<ul>`, `<pre><code>` 等の要素が存在することをアサート |
+| `<title>` が正しい形式になっている | **可** | `<title>` タグの内容を取得し、`{タイトル} \| KotaServer` 形式をアサート |
+| WikiLayout のヘッダー・フッター・コンテンツエリアが存在する | **可** | 各セクションのセマンティック要素（`<header>`, `<footer>`, `<main>` 等）の存在をアサート |
+
+### Iteration 3: ページ一覧
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| カード一覧が表示される | **可** | `dist/wiki/index.html` 内のカード要素数をアサート |
+| タイトルと更新日時が表示されている | **可** | 各カード内のテキスト内容をアサート |
+| 更新日時の降順で並んでいる | **可** | カード要素を順に取得し、日時の降順をアサート |
+| カードのリンク先が正しい | **可** | `<a href>` 属性が `/wiki/{slug}` 形式であることをアサート |
+| 0 件の場合にエラーにならない | **可** | フィクスチャを空配列にしてビルドし、`dist/wiki/index.html` が生成されることをアサート |
+
+### Iteration 4: ナビゲーション連携
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| ナビゲーションメニューが表示される | **可** | HTML 内のナビ要素にメニュー項目が存在することをアサート |
+| リンクをクリックして正しいページに遷移する | **可** | ナビのリンク `href` が正しい `/wiki/{slug}` を指していることをアサート |
+| トップページリンクが先頭に表示される | **可** | ナビの最初のリンクが `/` であることをアサート |
+| 並び順が反映される | **可** | ナビ項目の順序がフィクスチャの `sortOrder` 順と一致することをアサート |
+
+### Iteration 5: メディア URL 解決 & OGP
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| 画像が正しく表示される | **可** | `<img src>` が `{CMS_API_URL}/media/...` 形式であることをアサート（実際の画像表示はブラウザ依存だが、URL の正しさは検証可能） |
+| OGP メタタグが設定されている | **可** | `<meta property="og:title">` 等の存在と値をアサート |
+| 一覧ページにもメタデータがある | **可** | `dist/wiki/index.html` のメタタグをアサート |
+
+### Iteration 6: Webhook 再ビルド
+
+| 手動テスト項目 | 自動化 | 方法 |
+|--------------|:------:|------|
+| Webhook が発火してサイトが再ビルドされる | **不可** | デプロイ先 CI/CD との結合であり、テストハーネスのスコープ外 |
+
+### 自動化できないもの
+
+| 項目 | 理由 |
+|------|------|
+| CSS の視覚的レイアウト | DOM 構造は検証できるが、「見た目が正しいか」はブラウザレンダリングが必要 |
+| レスポンシブ表示 | ビューポートサイズごとの表示はブラウザが必要 |
+| Webhook 再ビルド | 外部 CI/CD サービスとの結合テスト |
+
+---
+
+## 3. 実装設計
+
+### 3.1 追加パッケージ
+
+```bash
+pnpm add -D cheerio
+```
+
+- **cheerio** — サーバーサイドの高速 HTML パーサー。jQuery ライクな API で DOM を操作・検索できる。ブラウザ不要
+- Vitest は Iteration 1 で導入済み
+
+### 3.2 ファイル構成
+
+```
+src/
+  lib/
+    __tests__/
+      cms-client.test.ts       # ユニットテスト（既存）
+      markdown.test.ts          # ユニットテスト（既存）
+      navigation.test.ts        # ユニットテスト（既存）
+  __tests__/
+    fixtures/
+      pages.json                # モック CMS レスポンス（ページ一覧）
+      navigation.json           # モック CMS レスポンス（ナビゲーション）
+      media.json                # モック CMS レスポンス（メディア）
+    helpers/
+      mock-cms-server.ts        # モック CMS HTTP サーバー
+      build.ts                  # astro build 実行ヘルパー
+      html.ts                   # HTML 読み込み・パースヘルパー
+    build-output/
+      iteration-1.test.ts       # Iteration 1 のビルド成果物検証
+      iteration-2.test.ts       # Iteration 2 のビルド成果物検証
+      iteration-3.test.ts       # Iteration 3 のビルド成果物検証
+      iteration-4.test.ts       # Iteration 4 のビルド成果物検証
+      iteration-5.test.ts       # Iteration 5 のビルド成果物検証
+```
+
+### 3.3 モック CMS サーバー
+
+テストプロセス内で `node:http` を使い、フィクスチャ JSON を返す軽量サーバーを起動する。
+
+```typescript
+// mock-cms-server.ts のイメージ
+import { createServer, type Server } from 'node:http';
+import pages from '../fixtures/pages.json';
+import navigation from '../fixtures/navigation.json';
+
+export function startMockCms(port = 18080): Promise<Server> {
+  const server = createServer((req, res) => {
+    // API キー検証
+    if (req.headers['x-api-key'] !== 'test-api-key') {
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+      return;
+    }
+
+    const url = new URL(req.url!, `http://localhost:${port}`);
+
+    if (url.pathname === '/api/v1/pages') {
+      res.end(JSON.stringify({ data: pages, total: pages.length, offset: 0, limit: 1000 }));
+    } else if (url.pathname.startsWith('/api/v1/pages/')) {
+      const slug = url.pathname.split('/').pop();
+      const page = pages.find(p => p.slug === slug);
+      page ? res.end(JSON.stringify(page)) : res.writeHead(404).end();
+    } else if (url.pathname === '/api/v1/navigation') {
+      res.end(JSON.stringify(navigation));
+    } else {
+      res.writeHead(404).end();
+    }
+  });
+
+  return new Promise(resolve => server.listen(port, () => resolve(server)));
+}
+```
+
+### 3.4 ビルド実行ヘルパー
+
+```typescript
+// build.ts のイメージ
+import { execSync } from 'node:child_process';
+
+export function runAstroBuild(env: Record<string, string>): void {
+  execSync('pnpm astro build', {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdio: 'pipe',
+  });
+}
+```
+
+### 3.5 HTML パースヘルパー
+
+```typescript
+// html.ts のイメージ
+import { readFileSync } from 'node:fs';
+import { load, type CheerioAPI } from 'cheerio';
+import { join } from 'node:path';
+
+const DIST_DIR = join(process.cwd(), 'dist');
+
+export function loadPage(path: string): CheerioAPI {
+  // '/wiki/test-slug' → 'dist/wiki/test-slug/index.html'
+  const filePath = join(DIST_DIR, path, 'index.html');
+  const html = readFileSync(filePath, 'utf-8');
+  return load(html);
+}
+```
+
+### 3.6 ビルド成果物テストの例
+
+```typescript
+// iteration-2.test.ts のイメージ
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { startMockCms } from '../helpers/mock-cms-server';
+import { runAstroBuild } from '../helpers/build';
+import { loadPage } from '../helpers/html';
+
+describe('Iteration 2: Markdown レンダリング & ページレイアウト', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = await startMockCms(18080);
+    runAstroBuild({
+      CMS_API_URL: 'http://localhost:18080',
+      CMS_API_KEY: 'test-api-key',
+    });
+  }, 60_000);
+
+  afterAll(() => server.close());
+
+  it('Markdown が HTML にレンダリングされている', () => {
+    const $ = loadPage('/wiki/getting-started');
+    expect($('article h2').length).toBeGreaterThan(0);
+    expect($('article p').length).toBeGreaterThan(0);
+  });
+
+  it('<title> が正しい形式になっている', () => {
+    const $ = loadPage('/wiki/getting-started');
+    expect($('title').text()).toMatch(/^.+ \| KotaServer/);
+  });
+
+  it('WikiLayout のセマンティック要素が存在する', () => {
+    const $ = loadPage('/wiki/getting-started');
+    expect($('header').length).toBe(1);
+    expect($('main').length).toBe(1);
+    expect($('footer').length).toBe(1);
+  });
+});
+```
+
+### 3.7 テスト実行戦略
+
+ビルド成果物テストは実行コストが高い（`astro build` に数秒かかる）ため、ユニットテストとは分離する。
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:build": "vitest run --project build",
+    "test:all": "vitest run && vitest run --project build"
+  }
+}
+```
+
+`vitest.config.ts` で Vitest の project 機能を使い分ける:
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['src/lib/__tests__/**/*.test.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'build',
+          include: ['src/__tests__/build-output/**/*.test.ts'],
+          testTimeout: 120_000,
+          pool: 'forks',
+          poolOptions: { forks: { singleFork: true } },
+        },
+      },
+    ],
+  },
+});
+```
+
+---
+
+## 4. イテレーション別テスト実装計画（改訂）
+
+| Iteration | ユニットテスト | ビルド成果物テスト |
+|:---------:|-------------|----------------|
+| 1 | `cms-client.test.ts` | テストハーネス基盤構築（モック CMS サーバー、ヘルパー、フィクスチャ）。`iteration-1.test.ts`（ページ表示、slug 存在確認） |
+| 2 | `markdown.test.ts` | `iteration-2.test.ts`（Markdown レンダリング、`<title>` 形式、WikiLayout 構造） |
+| 3 | — | `iteration-3.test.ts`（カード一覧、表示項目、ソート順、リンク先、0 件ケース） |
+| 4 | `navigation.test.ts` | `iteration-4.test.ts`（ナビメニュー表示、リンク先、先頭固定、並び順） |
+| 5 | `markdown.test.ts` 追加 | `iteration-5.test.ts`（画像 URL 解決、OGP メタタグ） |
+| 6 | — | — （Webhook は外部 CI/CD のため対象外） |
+
+---
+
+## 5. 制約と許容事項
+
+| 項目 | 対応 |
+|------|------|
+| CSS の視覚的レイアウト | DOM 構造の存在確認で代替する。「正しく見えるか」ではなく「正しい構造か」を検証する。エージェント自走ワークフローでは許容範囲 |
+| ビルド成果物テストの実行時間 | 1 回のビルドに数秒〜十数秒かかる。イテレーション内で 1 回のビルドを共有し、複数テストケースで検証する |
+| Webhook 再ビルド | テストハーネスのスコープ外。デプロイ後に手動確認 |
+| 画像の実際の表示 | URL の正しさは検証できるが、画像が実際にレンダリングされるかはブラウザ依存。URL 検証で十分とする |

--- a/projects/wiki/docs/testing-strategy.md
+++ b/projects/wiki/docs/testing-strategy.md
@@ -1,0 +1,494 @@
+# KotaServer Wiki テスト戦略
+
+## 概要
+
+本ドキュメントは KotaServer Wiki プロジェクトのテスト方針を定める。
+SSG（静的サイト生成）というアーキテクチャ特性を踏まえ、ビルド時ロジックの信頼性確保に重点を置く。
+
+実装はエージェントが自走するワークフローを想定しており、人間の目視確認に依存しないテスト自動化を目指す。
+
+**参照ドキュメント**: [要件定義書](requirements.md), [仕様書](specification.md), [実装計画書](impl-plan.md), [テストハーネス検討](testing-harness-analysis.md)
+
+---
+
+## 1. テスト対象の分析
+
+### 1.1 テスト可能なレイヤー
+
+| レイヤー | 対象 | リスク | テスト優先度 |
+|---------|------|--------|:----------:|
+| API クライアント | `cms-client.ts` — fetch ラッパー、認証ヘッダー付与、エラーハンドリング | CMS との接続が全機能の基盤。障害時ビルドが失敗する | **高** |
+| Markdown レンダリング | `marked` による変換、画像 URL 解決（`/media/` → CMS URL） | 不正な HTML 出力やリンク切れが直接ユーザー体験に影響 | **高** |
+| 型定義 | `types.ts` — CMS レスポンスの型 | TypeScript コンパイラが検証するため、テスト不要 | — |
+| Astro コンポーネント | Navigation, WikiCard, WikiLayout, ページテンプレート | 主にテンプレート。ロジックは少なく、目視確認が効率的 | **低** |
+| ナビゲーション構築 | `pageId` → slug 解決、`sortOrder` ソート、未公開ページのフィルタ | ロジックが複雑でエッジケースがある | **中** |
+
+### 1.2 テスト対象外
+
+- **Astro フレームワーク自体の動作**（ルーティング、`getStaticPaths` の仕組み等）
+- **CMS サーバー（kotaserver-web-admin）** — 別リポジトリで管理・テスト
+- **CI/CD・Webhook 連携** — インフラ設定であり、デプロイ後に手動確認で対応
+
+---
+
+## 2. テストツール
+
+### 2.1 採用ツール
+
+| ツール | 用途 | 選定理由 |
+|-------|------|---------|
+| **Vitest** | ユニットテスト | Astro 公式推奨。Vite ベースで高速。ESM ネイティブ対応。`import.meta.env` との互換性あり |
+
+### 2.2 採用ツール（補助）
+
+| ツール | 用途 | 選定理由 |
+|-------|------|---------|
+| **cheerio** | ビルド成果物の HTML パース | jQuery ライクな API で DOM を検索・検証できる。ブラウザ不要。軽量 |
+| **Playwright** | スクリーンショット撮影 | ビルド成果物を実際にブラウザでレンダリングし、スクリーンショットを保存する。エージェントが画像を読み込んで視覚的に確認する |
+
+### 2.3 不採用ツール
+
+| ツール | 不採用理由 |
+|-------|-----------|
+| Jest | ESM 対応が不完全。Astro プロジェクトでは Vitest が推奨 |
+| Testing Library | Astro コンポーネントのレンダリングテストは公式サポートが限定的。ロジックをユーティリティに切り出してテストする方が効率的 |
+
+### 2.4 セットアップ
+
+```bash
+pnpm add -D vitest cheerio @playwright/test
+npx playwright install chromium
+```
+
+`vitest.config.ts`:
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          globals: true,
+          environment: 'node',
+          include: ['src/lib/__tests__/**/*.test.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'build',
+          globals: true,
+          environment: 'node',
+          include: ['src/__tests__/build-output/**/*.test.ts'],
+          testTimeout: 120_000,
+          pool: 'forks',
+          poolOptions: { forks: { singleFork: true } },
+        },
+      },
+    ],
+  },
+});
+```
+
+`playwright.config.ts`:
+```typescript
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/__tests__/screenshots',
+  outputDir: './test-results',
+  use: {
+    baseURL: 'http://localhost:4321',
+  },
+  webServer: {
+    command: 'pnpm astro preview',
+    port: 4321,
+    reuseExistingServer: true,
+  },
+});
+```
+
+`package.json` に追加:
+```json
+{
+  "scripts": {
+    "test": "vitest run --project unit",
+    "test:build": "vitest run --project build",
+    "test:screenshots": "playwright test",
+    "test:all": "vitest run && playwright test"
+  }
+}
+```
+
+---
+
+## 3. テスト方針
+
+### 3.1 基本原則
+
+1. **ロジックをテストし、テンプレートはテストしない** — Astro コンポーネント（`.astro`）のレンダリングテストは行わない。テスト可能なロジックは `.ts` ファイルに切り出す
+2. **CMS API はモックする** — ユニットテストでは `fetch` を `vi.fn()` でモック。ビルド成果物テスト・スクリーンショット確認ではモック CMS サーバー（`node:http`）を起動する
+3. **ビルド成果物を検証する** — `astro build` で生成された `dist/` 内の HTML を cheerio でパースし、DOM 構造・テキスト内容・属性値をアサートする
+4. **スクリーンショットでエージェントが視覚確認する** — Playwright でスクリーンショットを撮影し���エージェントが画像を読み込んで CSS レイアウト・レスポンシブ表示を確認する。人間の目視確認を代替する
+5. **テストはイテレーションと同時に書く** — 実装と同じイテレーションでテストを追加する
+
+### 3.2 テスト分類
+
+```
+ユニットテスト（Vitest, test:unit）
+├── API クライアントの関数単位テスト
+├── Markdown レンダリングのロジックテスト
+└── ナビゲーション構築ロジックのテスト
+
+ビルド成果物テスト（Vitest, test:build）
+├── モック CMS サーバーを起動
+├── astro build を実行
+└── dist/ 内の HTML を cheerio でパースして検証
+    ├── ページ表示（タイトル、本文、構造）
+    ├── Markdown レンダリング結果
+    ├── ページ一覧（カード、ソート順、リンク先）
+    ├── ナビゲーション（メニュー項目、リンク、並び順）
+    ├── メディア URL 解決（画像 src 属性）
+    └── OGP メタタグ
+
+スクリーンショット確認（Playwright, test:screenshots）
+├── ビルド成果物を astro preview で配信
+├── Playwright でページを開きスクリーンショットを撮影
+├── 複数ビューポート（デスクトップ・モバイル）で撮影
+└── エージェントが画像を読み込み視覚的に確認
+    ├── レイアウトが崩れていないか
+    ├── CSS スタイリングが適用されているか
+    └── レスポンシブで要素が適切に配置されて��るか
+
+自動化対象外
+└── Webhook 再ビルド（外部 CI/CD との結合）
+```
+
+---
+
+## 4. テストケース
+
+### 4.1 API クライアント（`cms-client.ts`）
+
+**テストファイル**: `src/lib/__tests__/cms-client.test.ts`
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | `fetchCms` が正しいヘッダーを付与する | `X-API-Key` ヘッダーが `CMS_API_KEY` の値で送信される |
+| 2 | `fetchCms` が正しい URL を構築する | `CMS_API_URL` + パスが正しく結合される |
+| 3 | `getPages` がページ一覧を返す | 正常レスポンスをパースして返す |
+| 4 | `getPageBySlug` が個別ページを返す | slug を URL に含めてリクエストし、レスポンスを返す |
+| 5 | `getNavigation` がナビゲーション一覧を返す | 正常レスポンスをパースして返す |
+| 6 | API エラー時に例外をスローする | 401/404/500 レスポンスで適切なエラーメッセージと共にスローする |
+| 7 | 環境変数未設定時にエラーになる | `CMS_API_URL` や `CMS_API_KEY` が未設定の場合、わかりやすいエラーメッセージをスローする |
+
+**モック方針**: `globalThis.fetch` を `vi.fn()` でモックする。
+
+```typescript
+// テスト例のイメージ
+describe('cms-client', () => {
+  beforeEach(() => {
+    vi.stubEnv('CMS_API_URL', 'http://localhost:8080');
+    vi.stubEnv('CMS_API_KEY', 'test-api-key');
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('sends X-API-Key header', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: [], total: 0, offset: 0, limit: 20 }))
+    );
+    await getPages();
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/pages?offset=0&limit=1000',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'test-api-key' }),
+      })
+    );
+  });
+});
+```
+
+### 4.2 Markdown レンダリング
+
+**テストファイル**: `src/lib/__tests__/markdown.test.ts`
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | 基本的な Markdown が HTML に変換される | 見出し、段落、リスト、コードブロックが正しい HTML になる |
+| 2 | `/media/` パスの画像が CMS URL に変換される | `![alt](/media/image.png)` → `<img src="http://localhost:8080/media/image.png">` |
+| 3 | 外部 URL の画像はそのまま維持される | `![alt](https://example.com/img.png)` → 変換されない |
+| 4 | 空文字列を渡した場合 | エラーにならず空文字列を返す |
+
+### 4.3 ナビゲーション構築ロジック
+
+**テストファイル**: `src/lib/__tests__/navigation.test.ts`
+
+ナビゲーション構築にロジック（`pageId` → slug 解決、ソート等）が含まれる場合、ヘルパー関数として切り出してテストする。
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | `sortOrder` 昇順でソートされる | ナビ項目が `sortOrder` の昇順に並ぶ |
+| 2 | `pageId` が存在するナビ項目にリンクが生成される | 公開済みページの slug から `/wiki/{slug}` リンクが生成される |
+| 3 | `pageId` が `null` のナビ項目はリンクなし | ラベルのみの項目が正しく処理される |
+| 4 | `pageId` に対応するページが未公開の場合 | 該当項目がフィルタされるか、リンクなしになる |
+
+### 4.4 ビルド成果物テスト
+
+SSG ビルドで生成された `dist/` 内の HTML をパースし、従来の手動目視確認に相当する検証を自動で行う。
+
+**共通基盤**:
+- モック CMS サーバー（`node:http`）をテストプロセス内で起動し、フィクスチャ JSON を返す
+- `astro build` をモック CMS 向けの環境変数で実行
+- 生成された HTML ファイルを cheerio でパースしてアサーション
+
+**テストファイル**: `src/__tests__/build-output/iteration-{N}.test.ts`
+
+#### Iteration 1: ページ表示
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | Wiki ページの HTML が生成される | `dist/wiki/{slug}/index.html` が存在する |
+| 2 | ページタイトルが表示される | HTML 内にフィクスチャのタイトルテキストが含まれる |
+| 3 | ページ本文が表示される | HTML 内にフィクスチャの本文テキストが含まれる |
+| 4 | 想定外の slug が生成されない | `dist/wiki/` 内のディレクトリがフィクスチャの slug のみ |
+
+#### Iteration 2: Markdown レンダリング & レイアウト
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | Markdown が HTML 要素に変換されている | `<h2>`, `<ul>`, `<pre><code>` 等の要素が存在する |
+| 2 | `<title>` が正しい形式 | `<title>` の内容が `{タイトル} \| KotaServer` にマッチする |
+| 3 | WikiLayout のセマンティック構造 | `<header>`, `<main>`, `<footer>` 要素が存在する |
+
+#### Iteration 3: ページ一覧
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | 一覧ページが生成される | `dist/wiki/index.html` が存在する |
+| 2 | カード要素がページ数分存在する | カード要素の数がフィクスチャのページ数と一致する |
+| 3 | カードにタイトルと更新日時がある | 各カード内にフィクスチャのタイトル・日時テキストが含まれる |
+| 4 | カードが更新日時の降順で並ぶ | カード要素を順に取得し、日時が降順であることを検証 |
+| 5 | カードのリンク先が正しい | `<a href>` が `/wiki/{slug}` 形式である |
+| 6 | 0 件の場合にビルドが成功する | 空配列フィクスチャでビルドし、`dist/wiki/index.html` が生成される |
+
+#### Iteration 4: ナビゲーション
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | ナビメニューが表示される | ナビ要素内にフィクスチャのラベルが含まれる |
+| 2 | リンク先が正しい | `pageId` 付きナビ項目の `<a href>` が `/wiki/{slug}` を指す |
+| 3 | トップページリンクが先頭 | ナビの最初のリンクが `/` である |
+| 4 | 並び順が `sortOrder` 順 | ナビ項目の順序がフィクスチャの `sortOrder` 昇順と一致する |
+
+#### Iteration 5: メディア URL & OGP
+
+| # | テストケース | 検証内容 |
+|---|------------|---------|
+| 1 | `/media/` 画像の URL が解決されている | `<img src>` が `{CMS_API_URL}/media/...` 形式である |
+| 2 | 外部画像 URL はそのまま | 外部 URL の `<img src>` が変換されていない |
+| 3 | OGP メタタグが設定されている | `og:title`, `og:type`, `og:url` の `<meta>` 要素が存在し値が正しい |
+| 4 | 一覧ページにもメタデータがある | `dist/wiki/index.html` にメタタグが存在する |
+
+### 4.5 スクリーンショット確認
+
+Playwright でビルド成果物をブラウザレンダリングし、スクリーンショットを撮影する。撮影した画像はエージェントが Read ツールで読み込み、視覚的に確認する。
+
+**目的**: DOM 構造テスト（cheerio）ではカバーできない CSS レイアウト・レスポンシブ表示の確認を、人間の目視確認なしで実現する。
+
+**仕組み**:
+- Playwright はスクリーンショットを撮影して保存するだけ（pass/fail の自動判定はしない）
+- エージェントが画像ファイルを読み込み、表示内容を確認して判断する
+- ベースライン画像の管理やピクセル比較は不要
+
+**テストファイル**: `src/__tests__/screenshots/capture.test.ts`
+
+**撮影対象**:
+
+| ページ | ビューポ���ト | 確認観点 |
+|--------|------------|---------|
+| `/wiki/{slug}`（個別ページ） | デスクトップ（1280x720） | レイアウト、Markdown レンダリング結果、ナビゲーション配置 |
+| `/wiki/{slug}`（個別ページ） | モバイル（375x667） | レスポンシブ対応、ナビゲーションの折り返し |
+| `/wiki/`（一覧ページ） | デスクトップ（1280x720） | カード一覧のグリッドレイアウト |
+| `/wiki/`（一覧ページ） | モバイル（375x667） | カードの縦並び |
+
+**実装イメージ**:
+
+```typescript
+import { test } from '@playwright/test';
+
+const viewports = {
+  desktop: { width: 1280, height: 720 },
+  mobile: { width: 375, height: 667 },
+};
+
+for (const [name, size] of Object.entries(viewports)) {
+  test(`wiki page - ${name}`, async ({ page }) => {
+    await page.setViewportSize(size);
+    await page.goto('/wiki/getting-started');
+    await page.screenshot({
+      path: `test-results/wiki-page-${name}.png`,
+      fullPage: true,
+    });
+  });
+
+  test(`wiki index - ${name}`, async ({ page }) => {
+    await page.setViewportSize(size);
+    await page.goto('/wiki/');
+    await page.screenshot({
+      path: `test-results/wiki-index-${name}.png`,
+      fullPage: true,
+    });
+  });
+}
+```
+
+**エージェントの確認フロー**:
+
+1. `playwright test` を実行してスクリーンショットを撮影
+2. `test-results/*.png` をRead ツールで読み込む
+3. 以下の観点で画像を確認:
+   - ページの主要な構造要素（ヘッダー、コンテンツ、フッター）が視認できるか
+   - テキストが読める状態で表示されているか
+   - レイアウトが明らかに崩れていないか（要素の重なり、はみ出し等）
+   - モバイルビューポートで適切にリフローされているか
+4. 問題があれば CSS を修正し、再撮影して確認
+
+---
+
+## 5. テストファイル配置
+
+```
+src/
+  lib/
+    __tests__/
+      cms-client.test.ts        # Iteration 1 で作成
+      markdown.test.ts           # Iteration 2 で作成
+      navigation.test.ts         # Iteration 4 で作成
+    cms-client.ts
+    types.ts
+  __tests__/
+    fixtures/
+      pages.json                 # モック CMS レスポンス（ページ一覧）
+      navigation.json            # モック CMS レスポンス（ナビゲーション）
+      media.json                 # モック CMS レスポンス（メディア）
+    helpers/
+      mock-cms-server.ts         # モック CMS HTTP サーバー
+      build.ts                   # astro build 実行ヘルパー
+      html.ts                    # HTML 読み込み・cheerio パースヘルパー
+    build-output/
+      iteration-1.test.ts        # Iteration 1 ビルド成果物検証
+      iteration-2.test.ts        # Iteration 2 ビルド成果物検証
+      iteration-3.test.ts        # Iteration 3 ビルド成果物検証
+      iteration-4.test.ts        # Iteration 4 ビルド成果物検証
+      iteration-5.test.ts        # Iteration 5 ビルド成果物検証
+    screenshots/
+      capture.test.ts            # Playwright スクリーンショット撮影
+playwright.config.ts             # Playwright 設定
+test-results/                    # スクリーンショット出力先（.gitignore に追加）
+```
+
+- ユニットテスト: 対象モジュールと同じディレクトリ内の `__tests__/` に配置
+- ビルド成果物テスト: `src/__tests__/build-output/` に配置。ヘルパーとフィクスチャは `src/__tests__/` 直下に共有
+- スクリーンショット: `src/__tests__/screenshots/` に Playwright テスト、`test-results/` に画像を出力
+
+---
+
+## 6. テストハーネス共通基盤
+
+### 6.1 モック CMS サーバー
+
+`node:http` で実装する軽量 HTTP サーバー。テストプロセス内で起動・停止する。
+
+- フィクスチャ JSON をエンドポイントごとに返す
+- `X-API-Key` ヘッダーの検証を行う（不正なキーには 401 を返す）
+- ポートは `18080`（実環境の `8080` と競合しない）
+
+### 6.2 ビルド実行ヘルパー
+
+`execSync` で `astro build` を実行する。環境変数をモック CMS 向けに差し替えて渡す。
+
+### 6.3 HTML パースヘルパー
+
+`dist/` 内の HTML ファイルを読み込み、cheerio の `CheerioAPI` オブジェクトを返す。パスの正規化（`/wiki/slug` → `dist/wiki/slug/index.html`）を内部で行う。
+
+---
+
+## 7. イテレーション別テスト計画
+
+| Iteration | ユニットテスト | ビルド成果物テスト | スクリーンショット確認 |
+|:---------:|-------------|----------------|------------------|
+| 1 | Vitest + cheerio セットアップ。`cms-client.test.ts` | テストハーネス基盤構築（モック CMS サーバー、ヘルパー、フィクスチャ）。`iteration-1.test.ts`（ページ表示、slug 確認） | — （CSS スタイリング未実装） |
+| 2 | `markdown.test.ts`（基本変換） | `iteration-2.test.ts`（Markdown レンダリング、`<title>` 形式、WikiLayout 構造） | Playwright セットアップ。`capture.test.ts` 作成。個別ページのスクリーンショットで Markdown レンダリング・WikiLayout を視覚確認 |
+| 3 | — | `iteration-3.test.ts`（カード一覧、表示項目、ソート順、リンク先、0 件ケース） | `capture.test.ts` に一覧ページを追加。カードグリッドレイアウトを視覚確認 |
+| 4 | `navigation.test.ts` + `cms-client.test.ts` 追加 | `iteration-4.test.ts`（ナビメニュー、リンク先、先頭固定、並び順） | ナビゲーションの表示・配置を視覚確認。モバイルビューポートでのレスポンシブ対応を確認 |
+| 5 | `markdown.test.ts` にメディア URL 解決追加 | `iteration-5.test.ts`（画像 URL 解決、OGP メタタグ） | 画像を含むページのスクリーンショットで画像表示を視覚確認 |
+| 6 | — | — | —（Webhook は外部 CI/CD のため対象外） |
+
+---
+
+## 8. CI 統合
+
+`package.json` の `build` スクリプトにユニットテスト実行を組み込む:
+
+```json
+{
+  "scripts": {
+    "build": "vitest run --project unit && astro check && astro build"
+  }
+}
+```
+
+ビルド成果物テスト（`test:build`）は `astro build` 自体を内部で実行するため、`build` スクリプトには含めない。スクリーンショット確認（`test:screenshots`）はエージェントが画像を目視するステップを含むため、CI パイプラインには組み込まず、エージェントの実装ワークフロー内で実行する。
+
+CI パイプラインでの実行順:
+
+```
+vitest run --project unit  →  astro check  →  astro build  →  vitest run --project build
+```
+
+エージェント実装ワークフローでの実行順:
+
+```
+vitest run --project unit  →  astro check  →  astro build  →  vitest run --project build  →  playwright test  →  エージェントがスクリーンショットを確認
+```
+
+---
+
+## 9. 判断の根拠
+
+### なぜ 3 層のテスト構成か
+
+本プロジェクトはエージェント自走ワークフローで実装するため、人間の介入なしに品質を担保する必要がある。各層の役割:
+
+| 層 | 目的 | 判定方法 |
+|---|------|---------|
+| ユニットテスト | ロジックの正しさ | 機械的（pass/fail） |
+| ビルド成果物テスト | HTML 構造・内容の正しさ | 機械的（pass/fail） |
+| スクリーンショット確認 | 視覚的な表示品質 | エージェントが画像を確認して判断 |
+
+### なぜスクリーンショットでエージェントが確認するか
+
+- CSS レイアウトやレスポンシブ表示は DOM 構造テストではカバーできない
+- 従来は人間が開発サーバーを開いて目視確認していたが、エージェント自走ワークフローでは人間が介入できない
+- AI エージェントはマルチモーダルであり、スクリーンショット画像を読み込んで表示内容を判断できる
+- VRT（ベースライン比較）と異なり、初回実装時から「正しく見えるか」を判断できる
+- ベースライン管理やピクセル比較の仕組みが不要で、導入・運用がシンプル
+
+### なぜ VRT（Visual Regression Testing）を採用しないか
+
+- VRT は初回にベースラインを生成するが、そのベースラインが「正しいか」は別途確認が必要
+- エージェントが画像を直接確認する方が、初回から判断可能で仕組みもシンプル
+- 環境間のフォントレンダリング差異によるノイズも問題にならない
+
+### なぜコンポーネントテストを行わないか
+
+- Astro コンポーネントは `.astro` 形式であり、テストランナーでのレンダリングサポートが限定的
+- コンポーネントのロジック部分はユーティリティ関数に切り出してユニットテストする方が確実かつ保守しやすい
+- コンポーネントの出力結果はビルド成果物テスト + スクリーンショット確認で検証する
+
+### 自動化対象外
+
+| 項目 | 理由 |
+|------|------|
+| Webhook 再ビルド | 外部 CI/CD サービスとの結合テスト。デプロイ後に手動確認 |


### PR DESCRIPTION
## Summary

- Wiki プロジェクトのテスト戦略書（`testing-strategy.md`）を新規作成
- テストハーネス検討書（`testing-harness-analysis.md`）を新規作成
- 実装計画書（`impl-plan.md`）に各イテレーションのテスト項目を追加

エージェント自走ワークフローを前提に、人間の目視確認に依存しない 3 層テスト構成を設計:

1. **ユニットテスト** (Vitest) — API クライアント、Markdown レンダリング、ナビゲーション構築ロジック
2. **ビルド成果物テスト** (Vitest + cheerio) — モック CMS サーバーでビルドし、生成 HTML の DOM 構造・内容・属性を検証
3. **スクリーンショット確認** (Playwright) — ビルド成果物をブラウザレンダリングし、エージェントが画像を読み込んで CSS レイアウト・レスポンシブ表示を視覚確認

## Test plan

- [ ] ドキュメントのみの変更のため、ビルドへの影響なし
- [ ] テスト戦略書と実装計画書の間で整合性が取れていることを確認
- [ ] テストハーネス検討書の分析結果がテスト戦略書に正しく反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)